### PR TITLE
Allow generating a value from a custom alphabet in RandomGenerator

### DIFF
--- a/src/Random/RandomGenerator.php
+++ b/src/Random/RandomGenerator.php
@@ -53,6 +53,19 @@ class RandomGenerator
     }
 
     /**
+     * @param string $alphabet String consisting of characters allowed in generated value.
+     * @param int $size
+     *
+     * @return Str
+     *
+     * @throws RandomBytesGenerateException
+     */
+    public function fromCustomAlphabet($alphabet, $size)
+    {
+        return $this->getRandom(new Str($alphabet), $size);
+    }
+
+    /**
      * @param Str $alphabet
      * @param int    $size
      *

--- a/tests/Random/RandomGeneratorTest.php
+++ b/tests/Random/RandomGeneratorTest.php
@@ -48,6 +48,16 @@ class RandomGeneratorTest extends PHPUnit_Framework_TestCase
         $this->assertRegExp("/^[" . $pattern . "]{32}$/", $string->__toString());
     }
 
+    public function testGenerateFromCustomAlphabet()
+    {
+        $alphabet = 'abcdef123';
+        $string = $this->generator->fromCustomAlphabet($alphabet, 32);
+        $pattern = $this->getPattern($alphabet);
+
+        $this->assertEquals(32, strlen($string));
+        $this->assertRegExp("/^[" . $pattern . "]{32}$/", $string->__toString());
+    }
+
     /**
      * @param string $alphabet
      *


### PR DESCRIPTION
I could use the ability to generate a random string from a custom alphabet. This pull request adds this feature.